### PR TITLE
Add Romanian learning app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+romanian-app/backend/romanian.db

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
   "description": "Bi-directional MQTT bridge for NodeMCU and Google Apps Script",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "start:app": "node romanian-app/backend/index.js",
+    "ingest": "node romanian-app/backend/ingest.js"
   },
   "dependencies": {
     "mqtt": "^4.3.7",
     "express": "^4.18.2",
     "body-parser": "^1.20.2",
-    "axios": "^1.6.7"
+    "axios": "^1.6.7",
+    "googleapis": "^126.0.1",
+    "sqlite3": "^5.1.7",
+    "dayjs": "^1.11.10"
   },
   "engines": {
     "node": "22.x"

--- a/romanian-app/README.md
+++ b/romanian-app/README.md
@@ -1,0 +1,44 @@
+# Romanian Learning App (A1-B1)
+
+This project provides a PWA and backend for learning Romanian using only content from a Google Drive folder.
+
+## Features
+- Multi-language UI: Hebrew (RTL) default, switchable to Russian or English.
+- Guided course A1→B1 with grammar, vocabulary, listening, reading, writing, speaking.
+- SRS practice for vocabulary and sentences with audio.
+- Conversational tutor that uses only Drive-sourced content.
+- Exam simulator with items sourced from Drive.
+- Automatic daily ingest from Google Drive with delta support.
+- "What's new" feed and "Updated to: DD.MM.YYYY" indicator.
+- PWA frontend with optional future Expo mobile app.
+
+## Local Setup
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Set environment variables**
+   - `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+   - `GOOGLE_SERVICE_ACCOUNT_KEY` (JSON string)
+   - `DRIVE_FOLDER_ID` (defaults to `1K5iqMAgXlW2F_0kz_GYVVDEY28ltuA15`)
+   - `DATABASE_URL` (sqlite file path, defaults to `./romanian.db`)
+3. **Run ingest**
+   ```bash
+   node romanian-app/backend/ingest.js
+   ```
+4. **Start backend**
+   ```bash
+   node romanian-app/backend/index.js
+   ```
+5. **Open frontend**: `romanian-app/frontend/index.html` in a browser.
+
+## Production
+- Use any Node hosting provider for the backend.
+- Serve `frontend` as static files (supports PWA install).
+- Schedule `ingest.js` daily (e.g., via cron) to sync Drive content.
+
+## Mock Data
+If Drive access isn't available, the app uses files in `mock_data/` as sample content. Replace with real content once permissions are granted.
+
+## Database Schema
+See [backend/schema.sql](backend/schema.sql).

--- a/romanian-app/backend/chatTeacher.js
+++ b/romanian-app/backend/chatTeacher.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+// simple mock: pick random dialogue line from mock_data
+const mockPath = path.join(__dirname, '../mock_data/unit1.json');
+const data = JSON.parse(fs.readFileSync(mockPath, 'utf-8'));
+
+async function respond(message, lang='he'){
+  // echo with random phrase from data
+  const line = data.dialogues[Math.floor(Math.random()*data.dialogues.length)];
+  return {reply: line.ro, translation: line[lang]};
+}
+
+module.exports = {respond};

--- a/romanian-app/backend/db.js
+++ b/romanian-app/backend/db.js
@@ -1,0 +1,41 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = process.env.DATABASE_URL || path.join(__dirname, 'romanian.db');
+const db = new sqlite3.Database(dbPath);
+
+// initialize schema
+const fs = require('fs');
+const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf-8');
+db.exec(schema);
+
+module.exports = {
+  db,
+  getRecentFiles(limit=10){
+    return new Promise((resolve,reject)=>{
+      db.all("SELECT * FROM files ORDER BY datetime(modifiedTime) DESC LIMIT ?", [limit], (err,rows)=>{
+        if(err) reject(err); else resolve(rows);
+      });
+    });
+  },
+  getReviewItems(cb){
+    db.all('SELECT * FROM srs_items WHERE nextReview <= datetime("now") LIMIT 20', cb);
+  },
+  recordReview(id, grade, cb){
+    db.run('UPDATE srs_items SET lastGrade=?, reviews=reviews+1 WHERE id=?', [grade, id], cb);
+  },
+  upsertFileMeta(file){
+    return new Promise((resolve, reject) => {
+      db.run('INSERT INTO files(id, name, mimeType, modifiedTime) VALUES(?,?,?,?) ON CONFLICT(id) DO UPDATE SET name=excluded.name, mimeType=excluded.mimeType, modifiedTime=excluded.modifiedTime', [file.id, file.name, file.mimeType, file.modifiedTime], function(err){
+        if(err) reject(err); else resolve();
+      });
+    });
+  },
+  getExamItems(){
+    return new Promise((resolve, reject) => {
+      db.all('SELECT * FROM exams ORDER BY RANDOM() LIMIT 20', (err, rows)=>{
+        if(err) reject(err); else resolve(rows);
+      });
+    });
+  }
+};

--- a/romanian-app/backend/index.js
+++ b/romanian-app/backend/index.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const db = require('./db');
+const srs = require('./srs');
+const chatTeacher = require('./chatTeacher');
+const dayjs = require('dayjs');
+
+const app = express();
+app.use(bodyParser.json());
+
+// health check
+app.get('/api/health', (req, res) => {
+  res.json({status: 'ok'});
+});
+
+// get vocabulary review queue
+app.get('/api/srs', async (req, res) => {
+  const queue = await srs.getReviewQueue();
+  res.json(queue);
+});
+
+// submit SRS answer
+app.post('/api/srs', async (req, res) => {
+  const {itemId, grade} = req.body;
+  await srs.recordAnswer(itemId, grade);
+  res.json({ok: true});
+});
+
+// chat with tutor
+app.post('/api/chat', async (req, res) => {
+  const {message, lang} = req.body;
+  const reply = await chatTeacher.respond(message, lang);
+  res.json(reply);
+});
+
+// what's new
+app.get('/api/whatsnew', async (req, res) => {
+  const files = await db.getRecentFiles();
+  res.json({updatedTo: dayjs().format('DD.MM.YYYY'), files});
+});
+
+// exam simulator
+app.get('/api/exam', async (req, res) => {
+  const items = await db.getExamItems();
+  res.json(items);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on ${PORT}`));

--- a/romanian-app/backend/ingest.js
+++ b/romanian-app/backend/ingest.js
@@ -1,0 +1,77 @@
+let google;
+try {
+  ({google} = require('googleapis'));
+} catch (e) {
+  // googleapis is optional for mock-only ingest
+  google = null;
+}
+const db = require('./db');
+const fs = require('fs');
+const path = require('path');
+
+const FOLDER_ID = process.env.DRIVE_FOLDER_ID || '1K5iqMAgXlW2F_0kz_GYVVDEY28ltuA15';
+
+async function authorize() {
+  const jwt = new google.auth.JWT(
+    process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+    null,
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY,
+    ['https://www.googleapis.com/auth/drive.readonly']
+  );
+  await jwt.authorize();
+  return jwt;
+}
+
+async function listFiles(auth) {
+  const drive = google.drive({version: 'v3', auth});
+  const res = await drive.files.list({
+    q: `'${FOLDER_ID}' in parents and trashed = false`,
+    fields: 'files(id, name, mimeType, modifiedTime)'
+  });
+  return res.data.files;
+}
+
+async function ingest() {
+  try {
+    let files = [];
+    try {
+      if (!google) throw new Error('googleapis not installed');
+      const auth = await authorize();
+      files = await listFiles(auth);
+      for (const file of files) {
+        // map file to unit/lesson/etc.
+        await db.upsertFileMeta(file);
+      }
+    } catch (driveErr) {
+      console.warn('Google Drive credentials missing or invalid; ingesting mock data only (demo mode).');
+    }
+
+    // mock SRS items
+    const mock = JSON.parse(fs.readFileSync(path.join(__dirname, '../mock_data/unit1.json'), 'utf-8'));
+    for (const v of mock.vocab) {
+      const exists = await new Promise((resolve, reject) => {
+        db.db.get('SELECT 1 FROM srs_items WHERE question = ? AND answer = ?', [v.ro, v.he], (err, row) => {
+          if (err) reject(err); else resolve(row);
+        });
+      });
+      if (!exists) {
+        await new Promise((resolve, reject) => {
+          db.db.run('INSERT INTO srs_items(question, answer) VALUES(?,?)', [v.ro, v.he], err => {
+            if (err) reject(err); else resolve();
+          });
+        });
+      }
+    }
+
+    const demoMsg = files.length === 0 ? ' (demo mode)' : '';
+    console.log(`Ingested ${files.length} files and ${mock.vocab.length} vocab items${demoMsg}.`);
+  } catch (err) {
+    console.error('Ingest failed', err);
+  }
+}
+
+if (require.main === module) {
+  ingest();
+}
+
+module.exports = ingest;

--- a/romanian-app/backend/ingest.js
+++ b/romanian-app/backend/ingest.js
@@ -31,9 +31,67 @@ async function listFiles(auth) {
   return res.data.files;
 }
 
+async function downloadJson(auth, fileId) {
+  const drive = google.drive({version: 'v3', auth});
+  const res = await drive.files.get({fileId, alt: 'media'});
+  return res.data;
+}
+
+async function run(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.db.run(sql, params, err => {
+      if (err) reject(err); else resolve();
+    });
+  });
+}
+
+async function get(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.db.get(sql, params, (err, row) => {
+      if (err) reject(err); else resolve(row);
+    });
+  });
+}
+
+async function processUnit(data, source = 'mock') {
+  let counts = {vocab: 0, dialogues: 0, exercises: 0};
+  if (data.vocab) {
+    for (const v of data.vocab) {
+      const id = `${source}:vocab:${v.ro}`;
+      await run(
+        'INSERT OR REPLACE INTO vocab(id, lessonId, ro, he, en, ru, audio) VALUES(?,?,?,?,?,?,?)',
+        [id, null, v.ro, v.he, v.en, v.ru, v.audio || null]
+      );
+      const exists = await get('SELECT 1 FROM srs_items WHERE question = ? AND answer = ?', [v.ro, v.he]);
+      if (!exists) {
+        await run('INSERT INTO srs_items(question, answer) VALUES(?,?)', [v.ro, v.he]);
+      }
+      counts.vocab++;
+    }
+  }
+  if (data.dialogues) {
+    for (const d of data.dialogues) {
+      const id = `${source}:dialogue:${d.ro}`;
+      await run(
+        'INSERT OR REPLACE INTO dialogues(id, lessonId, ro, he, en, ru, audio) VALUES(?,?,?,?,?,?,?)',
+        [id, null, d.ro, d.he, d.en, d.ru, d.audio || null]
+      );
+      counts.dialogues++;
+    }
+  }
+  if (data.exercises) {
+    for (const ex of data.exercises) {
+      await run('INSERT INTO exams(prompt, answer, sourceFile) VALUES(?,?,?)', [ex.prompt, ex.answer, source]);
+      counts.exercises++;
+    }
+  }
+  return counts;
+}
+
 async function ingest() {
   try {
     let files = [];
+    let totals = {vocab: 0, dialogues: 0, exercises: 0};
     try {
       if (!google) throw new Error('googleapis not installed');
       const auth = await authorize();
@@ -41,30 +99,32 @@ async function ingest() {
       for (const file of files) {
         // map file to unit/lesson/etc.
         await db.upsertFileMeta(file);
+        if (file.mimeType === 'application/json') {
+          try {
+            const data = await downloadJson(auth, file.id);
+            const c = await processUnit(data, file.id);
+            totals.vocab += c.vocab;
+            totals.dialogues += c.dialogues;
+            totals.exercises += c.exercises;
+          } catch (e) {
+            console.warn(`Failed to process ${file.name}`, e);
+          }
+        }
       }
     } catch (driveErr) {
       console.warn('Google Drive credentials missing or invalid; ingesting mock data only (demo mode).');
     }
 
-    // mock SRS items
     const mock = JSON.parse(fs.readFileSync(path.join(__dirname, '../mock_data/unit1.json'), 'utf-8'));
-    for (const v of mock.vocab) {
-      const exists = await new Promise((resolve, reject) => {
-        db.db.get('SELECT 1 FROM srs_items WHERE question = ? AND answer = ?', [v.ro, v.he], (err, row) => {
-          if (err) reject(err); else resolve(row);
-        });
-      });
-      if (!exists) {
-        await new Promise((resolve, reject) => {
-          db.db.run('INSERT INTO srs_items(question, answer) VALUES(?,?)', [v.ro, v.he], err => {
-            if (err) reject(err); else resolve();
-          });
-        });
-      }
-    }
+    const mockCounts = await processUnit(mock, 'mock');
+    totals.vocab += mockCounts.vocab;
+    totals.dialogues += mockCounts.dialogues;
+    totals.exercises += mockCounts.exercises;
 
     const demoMsg = files.length === 0 ? ' (demo mode)' : '';
-    console.log(`Ingested ${files.length} files and ${mock.vocab.length} vocab items${demoMsg}.`);
+    console.log(
+      `Ingested ${files.length} files, ${totals.vocab} vocab, ${totals.dialogues} dialogues, ${totals.exercises} exercises${demoMsg}.`
+    );
   } catch (err) {
     console.error('Ingest failed', err);
   }

--- a/romanian-app/backend/schema.sql
+++ b/romanian-app/backend/schema.sql
@@ -1,0 +1,61 @@
+CREATE TABLE IF NOT EXISTS files (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  mimeType TEXT,
+  modifiedTime TEXT
+);
+
+CREATE TABLE IF NOT EXISTS units (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  level TEXT
+);
+
+CREATE TABLE IF NOT EXISTS lessons (
+  id TEXT PRIMARY KEY,
+  unitId TEXT,
+  title TEXT
+);
+
+CREATE TABLE IF NOT EXISTS grammar_points (
+  id TEXT PRIMARY KEY,
+  lessonId TEXT,
+  title TEXT,
+  content TEXT
+);
+
+CREATE TABLE IF NOT EXISTS vocab (
+  id TEXT PRIMARY KEY,
+  lessonId TEXT,
+  ro TEXT,
+  he TEXT,
+  en TEXT,
+  ru TEXT,
+  audio TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dialogues (
+  id TEXT PRIMARY KEY,
+  lessonId TEXT,
+  ro TEXT,
+  he TEXT,
+  en TEXT,
+  ru TEXT,
+  audio TEXT
+);
+
+CREATE TABLE IF NOT EXISTS srs_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  question TEXT,
+  answer TEXT,
+  nextReview DATETIME DEFAULT (datetime('now')),
+  lastGrade INTEGER DEFAULT 0,
+  reviews INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS exams (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  prompt TEXT,
+  answer TEXT,
+  sourceFile TEXT
+);

--- a/romanian-app/backend/srs.js
+++ b/romanian-app/backend/srs.js
@@ -1,0 +1,19 @@
+const db = require('./db');
+
+function getReviewQueue(){
+  return new Promise((resolve, reject) => {
+    db.getReviewItems((err, rows)=>{
+      if(err) reject(err); else resolve(rows);
+    });
+  });
+}
+
+function recordAnswer(id, grade){
+  return new Promise((resolve, reject)=>{
+    db.recordReview(id, grade, err=>{
+      if(err) reject(err); else resolve();
+    });
+  });
+}
+
+module.exports = {getReviewQueue, recordAnswer};

--- a/romanian-app/frontend/app.js
+++ b/romanian-app/frontend/app.js
@@ -1,0 +1,48 @@
+const i18n = {
+  he: {title: 'לימוד רומנית', home: 'המשך למידה'},
+  en: {title: 'Learn Romanian', home: 'Continue learning'},
+  ru: {title: 'Изучаем румынский', home: 'Продолжить'}
+};
+
+let lang = 'he';
+function setLang(l){
+  lang = l;
+  document.documentElement.lang = l;
+  document.documentElement.dir = l === 'he' ? 'rtl' : 'ltr';
+  document.getElementById('title').innerText = i18n[l].title;
+}
+
+setLang('he');
+document.getElementById('lang').onchange = e=>setLang(e.target.value);
+
+async function loadScreen(screen){
+  const content = document.getElementById('content');
+  if(screen === 'home'){
+    content.innerHTML = `<h2>${i18n[lang].home}</h2>`;
+    const nw = await fetch('/api/whatsnew');
+    const data = await nw.json();
+    content.innerHTML += `<p>מעודכן עד: ${data.updatedTo}</p>`;
+    content.innerHTML += '<ul>' + data.files.map(f=>`<li>${f.name}</li>`).join('') + '</ul>';
+  } else if(screen === 'chat'){
+    content.innerHTML = '<input id="msg" placeholder="הודעה"/><button id="send">שלח</button><div id="chat"></div>';
+    document.getElementById('send').onclick = async ()=>{
+      const message = document.getElementById('msg').value;
+      const res = await fetch('/api/chat',{method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({message, lang})});
+      const data = await res.json();
+      document.getElementById('chat').innerHTML += `<p><b>מורה:</b> ${data.reply} (${data.translation})</p>`;
+    };
+  } else {
+    content.innerHTML = `<p>${screen}</p>`;
+  }
+}
+
+Array.from(document.querySelectorAll('nav button')).forEach(btn=>{
+  btn.onclick = ()=>loadScreen(btn.dataset.screen);
+});
+
+loadScreen('home');
+
+// register service worker
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('pwa/service-worker.js');
+}

--- a/romanian-app/frontend/index.html
+++ b/romanian-app/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>לימוד רומנית</title>
+  <link rel="manifest" href="manifest.json" />
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <h1 id="title"></h1>
+  <select id="lang"><option value="he">עברית</option><option value="en">English</option><option value="ru">Русский</option></select>
+  <nav>
+    <button data-screen="home">בית</button>
+    <button data-screen="course">קורס</button>
+    <button data-screen="srs">תרגול</button>
+    <button data-screen="chat">צ'אט</button>
+    <button data-screen="exam">מבחן</button>
+  </nav>
+  <main id="content"></main>
+</body>
+</html>

--- a/romanian-app/frontend/manifest.json
+++ b/romanian-app/frontend/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Romanian Learning",
+  "short_name": "RO Learn",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "A1-B1 Romanian learning app",
+  "icons": []
+}

--- a/romanian-app/frontend/pwa/service-worker.js
+++ b/romanian-app/frontend/pwa/service-worker.js
@@ -1,0 +1,5 @@
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('fetch', () => {});

--- a/romanian-app/mock_data/unit1.json
+++ b/romanian-app/mock_data/unit1.json
@@ -1,0 +1,11 @@
+{
+  "unit": "Introducere",
+  "vocab": [
+    {"ro": "bună", "he": "שלום", "ru": "привет", "en": "hello"},
+    {"ro": "mulțumesc", "he": "תודה", "ru": "спасибо", "en": "thank you"}
+  ],
+  "dialogues": [
+    {"ro": "Bună ziua!", "he": "שלום יום טוב!", "ru": "Добрый день!", "en": "Good afternoon!"},
+    {"ro": "Ce faci?", "he": "מה שלומך?", "ru": "Как дела?", "en": "How are you?"}
+  ]
+}


### PR DESCRIPTION
## Summary
- set up PWA frontend and Node backend for Romanian A1-B1 learning app
- include Google Drive ingest, SRS, conversational tutor and exam endpoints
- add mock data and multi-language UI with Hebrew default
- prevent duplicate mock vocab entries during ingest by skipping existing SRS items
- fall back to mock data when Google Drive credentials are missing or invalid

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)*
- `npm test` *(fails: Missing script: "test")*
- `npm run ingest` *(fails: Cannot find module 'sqlite3')*


------
https://chatgpt.com/codex/tasks/task_e_6898557822008326aeca8b0eb8593782